### PR TITLE
kernelextension: Try findspark

### DIFF
--- a/extension/sparkmonitor/kernelextension.py
+++ b/extension/sparkmonitor/kernelextension.py
@@ -19,7 +19,12 @@ except ImportError:
 try:
     from pyspark import SparkConf
 except ImportError:
-    spark_imported = False
+    try:
+        import findspark
+        findspark.init()
+        from pyspark import SparkConf
+    except Exception:
+        spark_imported = False
 
 
 class ScalaMonitor:


### PR DESCRIPTION
If import pyspark fails, try the import findspark and findspark.init()
as a last resort.